### PR TITLE
feat: username search endpoint for autofill suggestions

### DIFF
--- a/concertcapsuleapi/views/user.py
+++ b/concertcapsuleapi/views/user.py
@@ -37,8 +37,39 @@ class UserView(ViewSet):
         exists = User.objects.filter(username__iexact=search_param).exists()
         return Response({"available": not exists})
 
+    @action(detail=False, methods=['get'])
+    def search(self, request):
+        search_param = request.GET.get('username', '')
+        if not search_param:
+            return Response([], status=status.HTTP_200_OK)
+
+        users = list(User.objects.filter(username__icontains=search_param))
+
+        # Sort by relevance
+        def sort_key(user):
+            username = user.username.lower()
+            search_lower = search_param.lower()
+
+            if username == search_lower:
+                return 0  # Exact match
+            elif username.startswith(search_lower):
+                return 1  # Starts with
+            else:
+                return 2  # Contains
+
+        users.sort(key=sort_key)
+
+        serializer = UsernameSearchSerializer(users, many=True)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
 
 class UserSerializer(serializers.ModelSerializer):
     class Meta:
         model = User
         fields = ('id', 'uid_firebase', 'username', 'first_name', 'last_name')
+
+
+class UsernameSearchSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ('username',)


### PR DESCRIPTION
Created a username search endpoint for the front end to be able to search for usernames for autofill suggestions. Sorts the results with preference towards exact matches or usernames that start the same as the search query.