### PR TITLE
Add PostgreSQL support for production deployment

### DIFF
--- a/concertcapsule/settings.py
+++ b/concertcapsule/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
 import os
+import dj_database_url
 from pathlib import Path
 from dotenv import load_dotenv
 
@@ -91,13 +92,17 @@ WSGI_APPLICATION = 'concertcapsule.wsgi.application'
 # Database
 # https://docs.djangoproject.com/en/4.2/ref/settings/#databases
 
-DATABASES = {
-    'default': {
-        'ENGINE': 'django.db.backends.sqlite3',
-        'NAME': BASE_DIR / 'db.sqlite3',
+if os.getenv('DATABASE_URL'):  # Production (Render)
+    DATABASES = {
+        'default': dj_database_url.parse(os.getenv('DATABASE_URL'))
     }
-}
-
+else:  # Development (Local SQLite)
+    DATABASES = {
+        'default': {
+            'ENGINE': 'django.db.backends.sqlite3',
+            'NAME': BASE_DIR / 'db.sqlite3',
+        }
+    }
 
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ certifi==2025.8.3
 charset-normalizer==3.4.3
 click==8.2.1
 dill==0.4.0
+dj-database-url==3.0.1
 Django==5.2.5
 django-cors-headers==4.7.0
 djangorestframework==3.16.1
@@ -14,6 +15,7 @@ isort==6.0.1
 mccabe==0.7.0
 packaging==25.0
 platformdirs==4.3.8
+psycopg2-binary==2.9.10
 pylint==3.3.7
 pylint-django==2.6.1
 pylint-plugin-utils==0.9.0


### PR DESCRIPTION
- Add dj-database-url and psycopg2-binary dependencies
- Configure settings.py to use PostgreSQL in production and SQLite in development
- Ready for Render PostgreSQL database connection