### PR TITLE
Fix HTTP 204 response in concert delete endpoint

### DIFF
--- a/concertcapsuleapi/views/concert.py
+++ b/concertcapsuleapi/views/concert.py
@@ -59,7 +59,7 @@ class ConcertView(viewsets.ViewSet):
             user_id=user
         )
         user_concert.delete()
-        return Response({"Concert successfully deleted"}, status=status.HTTP_204_NO_CONTENT)
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
     @action(detail=True, methods=['post'], url_path='add-to-profile', url_name='add-to-profile')
     def add_to_profile(self, request, pk=None):


### PR DESCRIPTION
- Remove response body from DELETE endpoint to comply with HTTP 204 No Content spec
- Fixes h11.LocalProtocolError: Too much data for declared Content-Length